### PR TITLE
ServerClientId needed for GoogleSignInOptions Web server OAuth #24

### DIFF
--- a/easygoogle/src/main/java/pub/devrel/easygoogle/Google.java
+++ b/easygoogle/src/main/java/pub/devrel/easygoogle/Google.java
@@ -49,6 +49,7 @@ public class Google {
         private FragmentActivity mActivity;
 
         private SignIn.SignInListener mSignInListener;
+        private String mServerClientId;
 
         private Messaging.MessagingListener mMessagingListener;
         private String mSenderId;
@@ -67,6 +68,18 @@ public class Google {
          * @return self, for chaining.
          */
         public Builder enableSignIn(SignIn.SignInListener signInListener) {
+            mSignInListener = signInListener;
+            return this;
+        }
+
+        /**
+         * Initialize {@link SignIn}.
+         * @param signInListener listener for sign in events.
+         * @param serverClientId client id for backend OAuth.
+         * @return self, for chaining.
+         */
+        public Builder enableSignIn(SignIn.SignInListener signInListener, String serverClientId) {
+            mServerClientId = serverClientId;
             mSignInListener = signInListener;
             return this;
         }
@@ -110,6 +123,9 @@ public class Google {
         public Google build() {
             Google google = new Google(mActivity);
             if (mSignInListener != null) {
+                if(mServerClientId != null) {
+                    google.mGacFragment.setServerClientId(mServerClientId);
+                }
                 google.mGacFragment.enableModule(SignIn.class, mSignInListener);
             }
 

--- a/easygoogle/src/main/java/pub/devrel/easygoogle/gac/GacFragment.java
+++ b/easygoogle/src/main/java/pub/devrel/easygoogle/gac/GacFragment.java
@@ -47,6 +47,8 @@ public class GacFragment extends Fragment implements
     private static final String KEY_IS_RESOLVING = "is_resolving";
     private static final String KEY_SHOULD_RESOLVE = "should_resolve";
 
+    private String mServerClientId;
+
     private GoogleApiClient mGoogleApiClient;
     private Map<Class<? extends GacModule>, GacModule> mModules = new HashMap<>();
 
@@ -274,6 +276,14 @@ public class GacFragment extends Fragment implements
      */
     public void setResolutionCode(int resolutionCode) {
         mResolutionCode = resolutionCode;
+    }
+
+    public void setServerClientId(String serverClientId) {
+        mServerClientId = serverClientId;
+    }
+
+    public String getServerClientId(){
+        return mServerClientId;
     }
 
     public GoogleApiClient getGoogleApiClient() {

--- a/easygoogle/src/main/java/pub/devrel/easygoogle/gac/SignIn.java
+++ b/easygoogle/src/main/java/pub/devrel/easygoogle/gac/SignIn.java
@@ -40,8 +40,13 @@ import java.util.List;
  * Interface to the Google Sign In API, which can be used to determine the users identity. The
  * default scopes "profile" and "email" are used to return basic information about the user
  * (when possible) however this does not grant any authorization to use other Google APIs on
- * behalf of the user. For more information visit:
+ * behalf of the user.  For more information visit:
  * https://developers.google.com/identity/sign-in/android/
+ *
+ * When registering OAuth clients for Google Sign-In, Web server OAuth client registration is needed
+ * with android by requesting an ID token in your GoogleSignInOptions, and supplying the web client
+ * ID for your server.  For more information visit:
+ * http://android-developers.blogspot.sg/2016/03/registering-oauth-clients-for-google.html
  */
 public class SignIn extends GacModule<SignIn.SignInListener> {
 
@@ -82,9 +87,16 @@ public class SignIn extends GacModule<SignIn.SignInListener> {
     @Override
     public Api.ApiOptions.HasOptions getOptionsFor(Api<? extends Api.ApiOptions> api) {
         if (Auth.GOOGLE_SIGN_IN_API.equals(api)) {
-            return new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                    .requestEmail()
-                    .build();
+            GoogleSignInOptions.Builder googleSignInOptions =  new GoogleSignInOptions.Builder(
+                    GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestEmail();
+
+            // Check server client id for OAuth, so GoogleSignInAccount.getIdToken(); is non-null
+            String serverClientId = getFragment().getServerClientId();
+            if(serverClientId != null){
+                googleSignInOptions.requestIdToken(serverClientId);
+            }
+            return googleSignInOptions.build();
         } else {
             return super.getOptionsFor(api);
         }

--- a/easygoogle/src/main/java/pub/devrel/easygoogle/gac/SignIn.java
+++ b/easygoogle/src/main/java/pub/devrel/easygoogle/gac/SignIn.java
@@ -40,12 +40,12 @@ import java.util.List;
  * Interface to the Google Sign In API, which can be used to determine the users identity. The
  * default scopes "profile" and "email" are used to return basic information about the user
  * (when possible) however this does not grant any authorization to use other Google APIs on
- * behalf of the user.  For more information visit:
+ * behalf of the user. For more information visit:
  * https://developers.google.com/identity/sign-in/android/
  *
  * When registering OAuth clients for Google Sign-In, Web server OAuth client registration is needed
  * with android by requesting an ID token in your GoogleSignInOptions, and supplying the web client
- * ID for your server.  For more information visit:
+ * ID for your server. For more information visit:
  * http://android-developers.blogspot.sg/2016/03/registering-oauth-clients-for-google.html
  */
 public class SignIn extends GacModule<SignIn.SignInListener> {


### PR DESCRIPTION
Here it is.

Question: Must the comments refer back to a developers.google.com domain or is an android-developers.blogspot.com permissible.

I point to:
http://android-developers.blogspot.com/2016/03/registering-oauth-clients-for-google.html
because it is up to date and has an accurate explanation.

However, weaker alternatives(which make no reference to the fix stated in the blogspot article) under the developers domain.google.com include both:
https://developers.google.com/identity/protocols/OAuth2WebServer
https://developers.google.com/identity/protocols/OAuth2
